### PR TITLE
Make font on tab-buttons visible

### DIFF
--- a/docs/.vitepress/theme/CustomLayout.vue
+++ b/docs/.vitepress/theme/CustomLayout.vue
@@ -197,6 +197,7 @@ const activeTab = ref("vanillaTsCode");
 .tab-buttons button {
   padding: 5px 10px;
   border: 1px solid #ccc;
+  color: #000000;
   background-color: #f0f0f0;
   cursor: pointer;
 }


### PR DESCRIPTION
While browsing the website on the dark theme, I notice the font on the tab-buttons was not visible.
Adding explicit color for the font make it readable.